### PR TITLE
Fixing sorting for latest tags, when alphanumeric gte 10

### DIFF
--- a/ver/git.go
+++ b/ver/git.go
@@ -183,7 +183,22 @@ func ListTags(reg *regexp.Regexp, limit int, changelog bool) ([]*CalVerTagGroup,
 	if err != nil {
 		return nil, err
 	}
+
 	sort.Slice(tags, func(i, j int) bool {
+		a := tags[i]
+		b := tags[j]
+		aBits := strings.Split(a, "-")
+		bBits := strings.Split(b, "-")
+		if aBits[0] != bBits[0] {
+			return bBits[0] < aBits[0]
+		}
+
+		if aMod, err := strconv.Atoi(aBits[1]); err == nil {
+			if bMod, err := strconv.Atoi(bBits[1]); err == nil {
+				return bMod < aMod
+			}
+		}
+
 		return tags[j] < tags[i]
 	})
 


### PR DESCRIPTION
## Information
Format: `YYYY.0M-AUTO`
Last Version: `2024.11-10`
Command: `git calver next --format="YYYY.0M-AUTO"`
Error:
```
tag 2024.11-10 already exists
```

## Description:
There was an issue when the increment was GTE 10. The `ver.ListTags` fn was reverse alphanumeric sorting the repo tags, which caused issues when the increment was above 9, because alphanumerically 9 is less than 11.

Have updated the logic to handle autoincrement reverse sorting.